### PR TITLE
Fix tflint and checkov

### DIFF
--- a/Облачная инфраструктура Terraform/Task5/modules/vm/main.tf
+++ b/Облачная инфраструктура Terraform/Task5/modules/vm/main.tf
@@ -25,7 +25,7 @@ data "template_file" "cloudinit" {
 }
 
 module "vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=09144db7f136b793064f1ac593fe2ac6921932f0"
   env_name       = var.env_name
   #network_id     = data.terraform_remote_state.vpc.outputs.network_id
   network_id     = var.network_id  

--- a/Облачная инфраструктура Terraform/Task5/variables.tf
+++ b/Облачная инфраструктура Terraform/Task5/variables.tf
@@ -37,8 +37,8 @@ variable "vpc_name" {
 
 ###ssh vars
 
-variable "ssh_public_keys" {
-  type        = list(string)
-  default     = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBTghPVe1t4te9AHfljmlRAm1U57qQkFZLqfYhUG8q+a xrdpuser@popmatrix007.fvds.ru","ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGiVcfW8Wa/DxbBNzmQcwn7hJOj7ji9eoTpFakVnY/AI webinar","ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtPnfjgdy85DXfFCEQBTA9syvs906biuj9kkVL2mjm1E+MEz1HGF/6FMNdeeWyFc3ks2qyXVSl1lVuV54fcUbo88UyQUvoj9p5U1+Y3vV+Ed7z3XN7IkHzHmJjfDaEySBT0upGQTQ2VkTJUxqEqsbJN2oAxDEPd+ltF0ecDDPrWfsnmQPTBeiaE+XUKqPg3wR8Lu8Iy20/9pf6+qjHwvFUWmneRLT6xJghpru8P/MYILo3cq3uvcWb7umHwh9aMBz6D/KNgLifTz0abSb/JrHkPjLhCec4z35qxDe9Ocsubtd4J/X3fRsh7qNYJwLsGoEmvixZCPJ3tDn8g0j7Z2tONQXkRTCRgEP4hI3z6+5MtRWQZ6E+MuhOASpAom7Ql3tFvYWsNAp/KyvXydSob3bHBe3UjnbXCIl+T9z9+GgHfEsyw+B3wuy5LknOjBu5lhn3dREIyJYcVJORwOMFAKm8mRd6ceiRjlykGrppLj26yq+y4IzZJFUEpbRvJ0b/HVE="]
-  description = "List of SSH public keys for VM access"
-}
+#variable "ssh_public_keys" {
+#  type        = list(string)
+#  default     = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBTghPVe1t4te9AHfljmlRAm1U57qQkFZLqfYhUG8q+a xrdpuser@popmatrix007.fvds.ru","ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGiVcfW8Wa/DxbBNzmQcwn7hJOj7ji9eoTpFakVnY/AI webinar","ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtPnfjgdy85DXfFCEQBTA9syvs906biuj9kkVL2mjm1E+MEz1HGF/6FMNdeeWyFc3ks2qyXVSl1lVuV54fcUbo88UyQUvoj9p5U1+Y3vV+Ed7z3XN7IkHzHmJjfDaEySBT0upGQTQ2VkTJUxqEqsbJN2oAxDEPd+ltF0ecDDPrWfsnmQPTBeiaE+XUKqPg3wR8Lu8Iy20/9pf6+qjHwvFUWmneRLT6xJghpru8P/MYILo3cq3uvcWb7umHwh9aMBz6D/KNgLifTz0abSb/JrHkPjLhCec4z35qxDe9Ocsubtd4J/X3fRsh7qNYJwLsGoEmvixZCPJ3tDn8g0j7Z2tONQXkRTCRgEP4hI3z6+5MtRWQZ6E+MuhOASpAom7Ql3tFvYWsNAp/KyvXydSob3bHBe3UjnbXCIl+T9z9+GgHfEsyw+B3wuy5LknOjBu5lhn3dREIyJYcVJORwOMFAKm8mRd6ceiRjlykGrppLj26yq+y4IzZJFUEpbRvJ0b/HVE="]
+#  description = "List of SSH public keys for VM access"
+#}


### PR DESCRIPTION
devops@shvirtd-19:~/shvirtd-19/Облачная инфраструктура Terraform/Task5$ checkov -d . --skip-download
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=modules/vm/cloud-init.yml
[ secrets framework ]:   0%|                    |[0/11]2025-07-29 05:06:33,814 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=09144db7f136b793064f1ac593fe2ac6921932f0 (for external modules, the --download-external-modules flag is required)
[ terraform framework ]: 100%|████████████████████|[10/10], Current File Scanned=variables.tf           l
[ secrets framework ]: 100%|████████████████████|[11/11], Current File Scanned=./modules/vm/versions.tf  

       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.2.457 

terraform scan results:

Passed checks: 2, Failed checks: 0, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: module.vm.vm
        File: /modules/vm/main.tf:27-48
        Calling File: /main.tf:8-16
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: module.vm.vm
        File: /modules/vm/main.tf:27-48
        Calling File: /main.tf:8-16

devops@shvirtd-19:~/shvirtd-19/Облачная инфраструктура Terraform/Task5$ tflint
1 issue(s) found:

Warning: [Fixable] variable "ssh_public_keys" is declared but not used (terraform_unused_declarations)

  on variables.tf line 40:
  40: variable "ssh_public_keys" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.12.0/docs/rules/terraform_unused_declarations.md

devops@shvirtd-19:~/shvirtd-19/Облачная инфраструктура Terraform/Task5$ nano variables.tf 
devops@shvirtd-19:~/shvirtd-19/Облачная инфраструктура Terraform/Task5$ tflint
devops@shvirtd-19:~/shvirtd-19/Облачная инфраструктура Terraform/Task5$ tflint


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # module.vm.data.template_file.cloudinit will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "template_file" "cloudinit" {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = <<-EOT
            #cloud-config
            users:
              - name: ubuntu
                groups: sudo
                shell: /bin/bash
                sudo: ["ALL=(ALL) NOPASSWD:ALL"]
                ssh_authorized_keys:
            ${ssh_keys}
            
            package_update: true
            package_upgrade: false
            packages:
              - vim
              - nginx
            
            runcmd:
              - [systemctl, enable, nginx]
              - [systemctl, start, nginx]
        EOT
      + vars     = {
          + "ssh_keys" = <<-EOT
                - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBTghPVe1t4te9AHfljmlRAm1U57qQkFZLqfYhUG8q+a xrdpuser@popmatrix007.fvds.ru
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGiVcfW8Wa/DxbBNzmQcwn7hJOj7ji9eoTpFakVnY/AI webinar
                      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCtPnfjgdy85DXfFCEQBTA9syvs906biuj9kkVL2mjm1E+MEz1HGF/6FMNdeeWyFc3ks2qyXVSl1lVuV54fcUbo88UyQUvoj9p5U1+Y3vV+Ed7z3XN7IkHzHmJjfDaEySBT0upGQTQ2VkTJUxqEqsbJN2oAxDEPd+ltF0ecDDPrWfsnmQPTBeiaE+XUKqPg3wR8Lu8Iy20/9pf6+qjHwvFUWmneRLT6xJghpru8P/MYILo3cq3uvcWb7umHwh9aMBz6D/KNgLifTz0abSb/JrHkPjLhCec4z35qxDe9Ocsubtd4J/X3fRsh7qNYJwLsGoEmvixZCPJ3tDn8g0j7Z2tONQXkRTCRgEP4hI3z6+5MtRWQZ6E+MuhOASpAom7Ql3tFvYWsNAp/KyvXydSob3bHBe3UjnbXCIl+T9z9+GgHfEsyw+B3wuy5LknOjBu5lhn3dREIyJYcVJORwOMFAKm8mRd6ceiRjlykGrppLj26yq+y4IzZJFUEpbRvJ0b/HVE=
            EOT
        }
    }

  # module.vpc.yandex_vpc_network.develop will be created
  + resource "yandex_vpc_network" "develop" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # module.vpc.yandex_vpc_subnet.develop will be created
  + resource "yandex_vpc_subnet" "develop" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

  # module.vm.module.vm.data.yandex_compute_image.my_image will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "yandex_compute_image" "my_image" {
      + created_at          = (known after apply)
      + description         = (known after apply)
      + family              = "ubuntu-2004-lts"
      + folder_id           = (known after apply)
      + hardware_generation = (known after apply)
      + id                  = (known after apply)
      + image_id            = (known after apply)
      + kms_key_id          = (known after apply)
      + labels              = (known after apply)
      + min_disk_size       = (known after apply)
      + name                = (known after apply)
      + os_type             = (known after apply)
      + pooled              = (known after apply)
      + product_ids         = (known after apply)
      + size                = (known after apply)
      + status              = (known after apply)
    }

  # module.vm.module.vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform yyy managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hardware_generation       = (known after apply)
      + hostname                  = "hw-04-remote-wm-1-0"
      + id                        = (known after apply)
      + labels                    = {
          + "owner" = "alexz"
        }
      + maintenance_grace_period  = (known after apply)
      + maintenance_policy        = (known after apply)
      + metadata                  = (known after apply)
      + name                      = "hw-04-remote-wm-1-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = (known after apply)
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + metadata_options (known after apply)

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + placement_policy (known after apply)

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.